### PR TITLE
issue #5 README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ LIFX_TOKEN=0000000000000000000000000000000000000000000000000000000000000000
 
 ``` php
 $api_token = 'token';
-$lifx = new Kz\Lifx($api_token);
+$lifx = new Kz\Lifx\Lifx($api_token);
 $lifx->toggleLights();
 ```
 


### PR DESCRIPTION
Easiest way is to fix the README file. As changing the namespace may irritate people who already use your classes.
